### PR TITLE
Add contact form with AWS SES and BlastCMS email templates

### DIFF
--- a/bradjolicoeur.core/OpenAPIs/swagger.json
+++ b/bradjolicoeur.core/OpenAPIs/swagger.json
@@ -4,16 +4,21 @@
     "title": "Blast CMS API",
     "description": "Blast CMS Content API",
     "contact": {
-      "name": "Brad Jolicoeur",
-      "url": "https://bradjolicoeur.com",
+      "name": "Blast CMS",
+      "url": "https://www.blastcms.net",
       "email": ""
     },
     "license": {
       "name": "Use under MIT",
-      "url": "https://example.com/license"
+      "url": "https://github.com/bradjolicoeur/blast-cms?tab=MIT-1-ov-file#readme"
     },
     "version": "v1"
   },
+  "servers": [
+    {
+      "url": "/blog-blastcms"
+    }
+  ],
   "paths": {
     "/api/blogarticle/all": {
       "get": {
@@ -73,7 +78,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -114,7 +119,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -154,7 +159,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -205,7 +210,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -271,7 +276,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -312,7 +317,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -352,7 +357,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -392,7 +397,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -443,7 +448,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -502,7 +507,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -553,11 +558,52 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AlterContentTagModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Api Key is not valid"
+          }
+        }
+      }
+    },
+    "/api/emailtemplate/id/{id}": {
+      "get": {
+        "tags": [
+          "Email Template"
+        ],
+        "summary": "Get Email Template",
+        "description": "Returns an Email Template",
+        "operationId": "GetEmailTemplate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "ApiKey",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailTemplate"
                 }
               }
             }
@@ -626,7 +672,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -708,7 +754,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -749,7 +795,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -789,7 +835,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -840,7 +886,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -906,7 +952,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -947,7 +993,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -987,7 +1033,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1038,7 +1084,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1104,7 +1150,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1145,7 +1191,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1218,7 +1264,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1259,7 +1305,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1299,7 +1345,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1350,7 +1396,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1401,7 +1447,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1467,7 +1513,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1508,7 +1554,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1548,7 +1594,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1599,7 +1645,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1680,7 +1726,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1721,7 +1767,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1772,7 +1818,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1812,7 +1858,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1853,7 +1899,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1893,7 +1939,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1944,7 +1990,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -2017,7 +2063,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -2076,7 +2122,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -2127,7 +2173,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -2186,7 +2232,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -2226,7 +2272,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -2277,7 +2323,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -2954,6 +3000,32 @@
         },
         "additionalProperties": false
       },
+      "EmailTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "fromAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "subject": {
+            "type": "string",
+            "nullable": true
+          },
+          "body": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "EventItem": {
         "type": "object",
         "properties": {
@@ -3408,6 +3480,15 @@
         },
         "additionalProperties": false
       },
+      "GetTenantExistsModel": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "ImageFile": {
         "type": "object",
         "properties": {
@@ -3807,6 +3888,61 @@
         "properties": {
           "data": {
             "$ref": "#/components/schemas/EventItem"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PutTenantCommand": {
+        "required": [
+          "challengeScheme",
+          "id",
+          "identifier",
+          "name",
+          "openIdConnectAuthority",
+          "openIdConnectClientId",
+          "openIdConnectClientSecret"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "identifier": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "identityTenantId": {
+            "type": "string",
+            "nullable": true
+          },
+          "openIdConnectClientId": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "openIdConnectAuthority": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "openIdConnectClientSecret": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "challengeScheme": {
+            "minLength": 1,
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/bradjolicoeur.core/bradjolicoeur.core.csproj
+++ b/bradjolicoeur.core/bradjolicoeur.core.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <OpenApiReference Include="OpenAPIs\swagger.json" CodeGenerator="NSwagCSharp" Namespace="bradjolicoeur.core.blastcms">
-      <SourceUri>https://blog-blastcms.bradjolicoeur.com/swagger/v1/swagger.json</SourceUri>
+      <SourceUri>https://app.blastcms.net/blog-blastcms/swagger/v1/swagger.json</SourceUri>
       <Options>/UseBaseUrl:false /GenerateClientInterfaces:true</Options>
       <ClassName>BlastCMSClient</ClassName>
     </OpenApiReference>

--- a/bradjolicoeur.web/Models/MailSettings.cs
+++ b/bradjolicoeur.web/Models/MailSettings.cs
@@ -1,0 +1,9 @@
+namespace bradjolicoeur.web.Models;
+
+public class MailSettings
+{
+    public string FromEmail { get; set; } = string.Empty;
+    public string NotificationEmail { get; set; } = string.Empty;
+    public string ContactTemplateId { get; set; } = string.Empty;
+    public string ConfirmationTemplateId { get; set; } = string.Empty;
+}

--- a/bradjolicoeur.web/Pages/Contact.cshtml
+++ b/bradjolicoeur.web/Pages/Contact.cshtml
@@ -1,0 +1,45 @@
+@page
+@model bradjolicoeur.web.Pages.ContactModel
+@{
+    ViewData["Title"] = "Contact Brad Jolicoeur";
+    ViewBag.Description = "Get in touch with Brad Jolicoeur — Principal Architect, VP Architecture, and Fractional CTO. Available for architecture consulting and leadership roles.";
+}
+
+<div class="container" style="max-width: 680px; margin: 3rem auto; padding: 0 1.5rem;">
+    <h1 style="color: #0f172a; font-size: 2rem; margin-bottom: 0.5rem;">Let's work on something real.</h1>
+    <p style="color: #64748b; margin-bottom: 2rem;">Tell me about the problem you're trying to solve.</p>
+
+    @if (Model.Submitted)
+    {
+        <div style="background: #f0fdf4; border: 1px solid #86efac; border-radius: 8px; padding: 1.5rem; margin-bottom: 2rem;">
+            <p style="color: #166534; margin: 0;"><strong>Message sent!</strong> I'll be in touch shortly.</p>
+        </div>
+    }
+    else
+    {
+        <form method="post">
+            @Html.AntiForgeryToken()
+            <div asp-validation-summary="ModelOnly" style="color: #dc2626; margin-bottom: 1rem;"></div>
+
+            <div style="margin-bottom: 1.25rem;">
+                <label asp-for="Input.Name" style="display: block; font-weight: 600; margin-bottom: 0.4rem; color: #0f172a;">Name</label>
+                <input asp-for="Input.Name" class="form-control" style="width: 100%; padding: 0.6rem 0.9rem; border: 1px solid #cbd5e1; border-radius: 6px; font-size: 1rem;" />
+                <span asp-validation-for="Input.Name" style="color: #dc2626; font-size: 0.875rem;"></span>
+            </div>
+
+            <div style="margin-bottom: 1.25rem;">
+                <label asp-for="Input.Email" style="display: block; font-weight: 600; margin-bottom: 0.4rem; color: #0f172a;">Email</label>
+                <input asp-for="Input.Email" type="email" class="form-control" style="width: 100%; padding: 0.6rem 0.9rem; border: 1px solid #cbd5e1; border-radius: 6px; font-size: 1rem;" />
+                <span asp-validation-for="Input.Email" style="color: #dc2626; font-size: 0.875rem;"></span>
+            </div>
+
+            <div style="margin-bottom: 1.75rem;">
+                <label asp-for="Input.Message" style="display: block; font-weight: 600; margin-bottom: 0.4rem; color: #0f172a;">Message</label>
+                <textarea asp-for="Input.Message" rows="6" class="form-control" style="width: 100%; padding: 0.6rem 0.9rem; border: 1px solid #cbd5e1; border-radius: 6px; font-size: 1rem; resize: vertical;"></textarea>
+                <span asp-validation-for="Input.Message" style="color: #dc2626; font-size: 0.875rem;"></span>
+            </div>
+
+            <button type="submit" style="background: #0ea5e9; color: white; border: none; padding: 0.75rem 2rem; border-radius: 6px; font-size: 1rem; font-weight: 600; cursor: pointer;">Send Message</button>
+        </form>
+    }
+</div>

--- a/bradjolicoeur.web/Pages/Contact.cshtml.cs
+++ b/bradjolicoeur.web/Pages/Contact.cshtml.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using bradjolicoeur.web.Models;
+using bradjolicoeur.web.Services;
+using bradjolicoeur.web.ViewModels;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
+
+namespace bradjolicoeur.web.Pages;
+
+public class ContactModel : PageModel
+{
+    private readonly IMailService _mailService;
+    private readonly IEmailTemplateService _emailTemplateService;
+    private readonly IValidator<ContactFormModel> _validator;
+    private readonly MailSettings _mailSettings;
+
+    public ContactModel(
+        IMailService mailService,
+        IEmailTemplateService emailTemplateService,
+        IValidator<ContactFormModel> validator,
+        IOptions<MailSettings> mailSettings)
+    {
+        _mailService = mailService;
+        _emailTemplateService = emailTemplateService;
+        _validator = validator;
+        _mailSettings = mailSettings.Value;
+    }
+
+    [BindProperty]
+    public ContactFormModel Input { get; set; } = new();
+
+    public bool Submitted { get; set; }
+
+    public void OnGet() { }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var validation = await _validator.ValidateAsync(Input);
+        if (!validation.IsValid)
+        {
+            foreach (var error in validation.Errors)
+                ModelState.AddModelError($"Input.{error.PropertyName}", error.ErrorMessage);
+            return Page();
+        }
+
+        var templateId = Guid.Parse(_mailSettings.ContactTemplateId);
+        var (subject, htmlBody) = await _emailTemplateService.RenderEmailTemplateAsync(templateId, new
+        {
+            Input.Name,
+            Input.Email,
+            Input.Message
+        });
+
+        await _mailService.SendEmailAsync(_mailSettings.NotificationEmail, subject, htmlBody);
+
+        var confirmationTemplateId = Guid.Parse(_mailSettings.ConfirmationTemplateId);
+        var (confirmationSubject, confirmationHtmlBody) = await _emailTemplateService.RenderEmailTemplateAsync(confirmationTemplateId, new
+        {
+            Input.Name,
+            Input.Email,
+            Input.Message
+        });
+        await _mailService.SendEmailAsync(Input.Email, confirmationSubject, confirmationHtmlBody);
+
+        Submitted = true;
+        ModelState.Clear();
+        Input = new ContactFormModel();
+        return Page();
+    }
+}

--- a/bradjolicoeur.web/Pages/Index.cshtml
+++ b/bradjolicoeur.web/Pages/Index.cshtml
@@ -135,7 +135,7 @@
         <p class="section-label">Get in Touch</p>
         <h2 class="contact-heading">Let's work on something real.</h2>
         <p class="contact-body">If you're working on a real architecture problem — or building the team to solve one — I'd like to hear about it.</p>
-        <a href="mailto:brad@bradjolicoeur.com" class="btn-primary">Send a message</a>
+        <a href="/contact" class="btn-primary">Send a message</a>
         <p class="contact-availability">Available for Principal Architect, VP Architecture, and Fractional CTO engagements. Let's talk.</p>
     </div>
 </section>

--- a/bradjolicoeur.web/Program.cs
+++ b/bradjolicoeur.web/Program.cs
@@ -4,6 +4,7 @@ using bradjolicoeur.core.Models;
 using bradjolicoeur.core.Services;
 using bradjolicoeur.web.Middleware;
 using bradjolicoeur.web.Services;
+using FluentValidation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -42,6 +43,18 @@ builder.Services.AddSingleton<IWebhookListener>(sp => new WebhookListener());
 
 builder.Services.AddScoped<IGenerateSitemapService, GenerateSitemapService>();
 builder.Services.AddTransient<ISuggestionArticlesService, SuggestionArticlesService>();
+
+// Mail services
+builder.Services.Configure<bradjolicoeur.web.Models.MailSettings>(Configuration.GetSection("MailSettings"));
+builder.Services.AddScoped<IMailService, MailService>();
+builder.Services.AddScoped<IEmailTemplateService, EmailTemplateService>();
+
+// AWS SES
+builder.Services.AddDefaultAWSOptions(Configuration.GetAWSOptions());
+builder.Services.AddAWSService<Amazon.SimpleEmailV2.IAmazonSimpleEmailServiceV2>();
+
+// FluentValidation
+builder.Services.AddValidatorsFromAssemblyContaining<bradjolicoeur.web.Validators.ContactFormValidator>();
 
 builder.Services.AddHttpClient<IBlastCMSClient, BlastCMSClient>(
     (provider, client) => {

--- a/bradjolicoeur.web/Program.cs
+++ b/bradjolicoeur.web/Program.cs
@@ -50,7 +50,12 @@ builder.Services.AddScoped<IMailService, MailService>();
 builder.Services.AddScoped<IEmailTemplateService, EmailTemplateService>();
 
 // AWS SES
-builder.Services.AddDefaultAWSOptions(Configuration.GetAWSOptions());
+var awsOptions = Configuration.GetAWSOptions();
+var accessKey = Configuration["AWS:AccessKey"];
+var secretKey = Configuration["AWS:SecretKey"];
+if (!string.IsNullOrEmpty(accessKey) && !string.IsNullOrEmpty(secretKey))
+    awsOptions.Credentials = new Amazon.Runtime.BasicAWSCredentials(accessKey, secretKey);
+builder.Services.AddDefaultAWSOptions(awsOptions);
 builder.Services.AddAWSService<Amazon.SimpleEmailV2.IAmazonSimpleEmailServiceV2>();
 
 // FluentValidation

--- a/bradjolicoeur.web/Services/EmailTemplateService.cs
+++ b/bradjolicoeur.web/Services/EmailTemplateService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using bradjolicoeur.core.blastcms;
+using LazyCache;
+using Markdig;
+using Microsoft.Extensions.Configuration;
+using Stubble.Core.Builders;
+
+namespace bradjolicoeur.web.Services;
+
+public class EmailTemplateService : IEmailTemplateService
+{
+    private readonly IBlastCMSClient _blastCmsClient;
+    private readonly IAppCache _cache;
+    private readonly string _apiKey;
+    private readonly MarkdownPipeline _markdownPipeline;
+
+    public EmailTemplateService(IBlastCMSClient blastCmsClient, IAppCache cache, IConfiguration configuration)
+    {
+        _blastCmsClient = blastCmsClient;
+        _cache = cache;
+        _apiKey = configuration["BlastCMSContentKey"] ?? string.Empty;
+        _markdownPipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+    }
+
+    public async Task<(string subject, string htmlBody)> RenderEmailTemplateAsync(Guid templateId, object model)
+    {
+        var template = await _cache.GetOrAddAsync(
+            $"email-template-{templateId}",
+            async () => await _blastCmsClient.GetEmailTemplateAsync(templateId, _apiKey)
+        );
+
+        if (template == null)
+            throw new InvalidOperationException($"Email template with ID {templateId} not found.");
+
+        var stubble = new StubbleBuilder().Build();
+
+        var renderedSubject = await stubble.RenderAsync(template.Subject ?? string.Empty, model);
+        var renderedBody = await stubble.RenderAsync(template.Body ?? string.Empty, model);
+        var htmlBody = Markdown.ToHtml(renderedBody, _markdownPipeline);
+
+        return (renderedSubject, htmlBody);
+    }
+}

--- a/bradjolicoeur.web/Services/IEmailTemplateService.cs
+++ b/bradjolicoeur.web/Services/IEmailTemplateService.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Threading.Tasks;
+
+namespace bradjolicoeur.web.Services;
+
+public interface IEmailTemplateService
+{
+    Task<(string subject, string htmlBody)> RenderEmailTemplateAsync(Guid templateId, object model);
+}

--- a/bradjolicoeur.web/Services/IMailService.cs
+++ b/bradjolicoeur.web/Services/IMailService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace bradjolicoeur.web.Services;
+
+public interface IMailService
+{
+    Task SendEmailAsync(string toEmail, string subject, string htmlBody);
+}

--- a/bradjolicoeur.web/Services/MailService.cs
+++ b/bradjolicoeur.web/Services/MailService.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using Amazon.SimpleEmailV2;
+using Amazon.SimpleEmailV2.Model;
+using bradjolicoeur.web.Models;
+using Microsoft.Extensions.Options;
+
+namespace bradjolicoeur.web.Services;
+
+public class MailService : IMailService
+{
+    private readonly MailSettings _mailConfig;
+    private readonly IAmazonSimpleEmailServiceV2 _emailService;
+
+    public MailService(IOptions<MailSettings> mailConfig, IAmazonSimpleEmailServiceV2 emailService)
+    {
+        _mailConfig = mailConfig.Value;
+        _emailService = emailService;
+    }
+
+    public async Task SendEmailAsync(string toEmail, string subject, string htmlBody)
+    {
+        var request = new SendEmailRequest
+        {
+            FromEmailAddress = _mailConfig.FromEmail,
+            Destination = new Destination { ToAddresses = [toEmail] },
+            Content = new EmailContent
+            {
+                Simple = new Message
+                {
+                    Subject = new Content { Data = subject },
+                    Body = new Body { Html = new Content { Data = htmlBody } }
+                }
+            }
+        };
+        await _emailService.SendEmailAsync(request);
+    }
+}

--- a/bradjolicoeur.web/Validators/ContactFormValidator.cs
+++ b/bradjolicoeur.web/Validators/ContactFormValidator.cs
@@ -1,0 +1,14 @@
+using bradjolicoeur.web.ViewModels;
+using FluentValidation;
+
+namespace bradjolicoeur.web.Validators;
+
+public class ContactFormValidator : AbstractValidator<ContactFormModel>
+{
+    public ContactFormValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Email).NotEmpty().EmailAddress().MaximumLength(200);
+        RuleFor(x => x.Message).NotEmpty().MaximumLength(2000);
+    }
+}

--- a/bradjolicoeur.web/ViewModels/ContactFormModel.cs
+++ b/bradjolicoeur.web/ViewModels/ContactFormModel.cs
@@ -1,0 +1,8 @@
+namespace bradjolicoeur.web.ViewModels;
+
+public class ContactFormModel
+{
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+}

--- a/bradjolicoeur.web/appsettings.json
+++ b/bradjolicoeur.web/appsettings.json
@@ -7,5 +7,11 @@
       "Microsoft": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "MailSettings": {
+    "FromEmail": "",
+    "NotificationEmail": "",
+    "ContactTemplateId": "",
+    "ConfirmationTemplateId": ""
+  }
 }

--- a/bradjolicoeur.web/bradjolicoeur.web.csproj
+++ b/bradjolicoeur.web/bradjolicoeur.web.csproj
@@ -16,10 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.7" />
+    <PackageReference Include="AWSSDK.SimpleEmailV2" Version="4.0.5.9" />
     <PackageReference Include="FluentCache.Microsoft.Extensions.Caching.Memory" Version="4.0.0.2" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Markdig" Version="0.38.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.1" />
+    <PackageReference Include="Stubble.Core" Version="1.10.8" />
     <PackageReference Include="WebEssentials.AspNetCore.PWA" Version="1.0.85" />
   </ItemGroup>
 

--- a/bradjolicoeur.web/secretsettings-template.json
+++ b/bradjolicoeur.web/secretsettings-template.json
@@ -1,3 +1,13 @@
 {
-
+  "MailSettings": {
+    "FromEmail": "brad@bradjolicoeur.com",
+    "NotificationEmail": "brad@bradjolicoeur.com",
+    "ContactTemplateId": "YOUR_BLASTCMS_EMAIL_TEMPLATE_GUID",
+    "ConfirmationTemplateId": "YOUR_BLASTCMS_CONFIRMATION_TEMPLATE_GUID"
+  },
+  "AWS": {
+    "Region": "us-east-1",
+    "AccessKey": "YOUR_AWS_ACCESS_KEY",
+    "SecretKey": "YOUR_AWS_SECRET_KEY"
+  }
 }


### PR DESCRIPTION
- Add contact form page with FluentValidation
- Add IMailService/MailService for AWS SES delivery
- Add IEmailTemplateService/EmailTemplateService for BlastCMS template rendering (Mustache + Markdown)
- Send notification email to site owner on submission
- Send confirmation email to submitter using BlastCMS template
- Update BlastCMS client (swagger.json + SourceUri) to use working app.blastcms.net endpoint
- Add AWS SES and Stubble.Core NuGet packages
- Update Index.cshtml mailto link to /contact page